### PR TITLE
install: Don't create unused directories

### DIFF
--- a/install.c
+++ b/install.c
@@ -127,6 +127,12 @@ install (const char *path, const char *relative_to, const char *destination_dir,
           return TRUE;
         }
 
+      if (g_mkdir_with_parents (destination_dir, 0755) < 0)
+        {
+          g_printerr ("Unable to create dir '%s': %s", destination_file, strerror (errno));
+          return FALSE;
+        }
+
       if (type == S_IFLNK)
         {
           res = unlink (destination_file);
@@ -173,22 +179,6 @@ install (const char *path, const char *relative_to, const char *destination_dir,
       g_autofree char *basename = g_path_get_basename (path);
       g_autofree char *destination_subdir
           = g_build_filename (destination_dir, toplevel ? NULL : basename, NULL);
-
-      if (!toplevel)
-        {
-          res = mkdir (destination_subdir, 0755);
-          if (res < 0)
-            {
-              if (errno != EEXIST)
-                {
-                  g_printerr ("Can't create directory '%s': %s\n", destination_subdir,
-                              strerror (errno));
-                  return FALSE;
-                }
-            }
-          else
-            g_info ("Created directory '%s'", destination_subdir);
-        }
 
       const char *child;
       while ((child = g_dir_read_name (dir)) != NULL)

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-VALIDATOR=$BUILDDIR/validator
-ASSETS=$SRCDIR/test-assets
+VALIDATOR=${BUILDDIR:-.}/validator
+ASSETS=${SRCDIR:-.}/test-assets
 
 set -e
 
@@ -25,6 +25,12 @@ assert_not_has_file () {
 
 assert_has_dir () {
     test -d "$1" || fatal "Couldn't find '$1'"
+}
+
+assert_not_has_dir () {
+    if test -d "$1"; then
+        fatal "Dir '$1' exists"
+    fi
 }
 
 # Dump ls -al + file contents to stderr, then fatal()
@@ -67,7 +73,7 @@ genkeys () {
 gencontent () {
     DIR=$1
     rm -rf $DIR
-    mkdir -p $DIR/dir
+    mkdir -p $DIR/dir $DIR/unused
     echo FILEDATA1 > $DIR/file1.txt
     echo FILEDATA2 > $DIR/file2.txt
     ln -s file1.txt  $DIR/symlink1
@@ -182,6 +188,9 @@ assert_has_file $COPY/symlink1
 assert_has_file $COPY/dir/file3.txt
 cmp $CONTENT/dir/file3.txt $COPY/dir/file3.txt
 assert_has_file $COPY/dir/symlink2
+
+# Dir with no validated file in should not be created
+assert_not_has_dir $COPY/unused
 
 HEADER Partial install
 rm -rf $COPY


### PR DESCRIPTION
Unless a (valid) file is copied into place, don't create the parent directories of it. Otherwise you can use this to create arbitrarily named directories, which may be a security problem.

Only if some file is valid with a particular path then is it safe to create the path.

Also add a test that verifies this.